### PR TITLE
feat(inlay-hint): Update for recent nvim v0.11.0 nightly

### DIFF
--- a/lua/inlay-hint/init.lua
+++ b/lua/inlay-hint/init.lua
@@ -78,7 +78,7 @@ function M.on_inlayhint(err, result, ctx, _)
     local col = position.character
     if col > 0 then
       local line = lines[position.line + 1] or ''
-      return util._str_byteindex_enc(line, col, client.offset_encoding)
+      return vim.str_byteindex(line, client.offset_encoding, col, false)
     end
     return col
   end


### PR DESCRIPTION
Following neovim/neovim#30915, `_str_byteindex_enc` is no longer available. I didn't take any time to understand the context of the call, but this change seemed to work fine for me.

Since this repository seems to track stable, this PR may not be very valuable. Hopefully it can help anyone else who may have run into this issue, though!