### PR TITLE
feat(inlay-hint): update to latest nightly API up to 2026-01-23

### DIFF
--- a/lua/inlay-hint/init.lua
+++ b/lua/inlay-hint/init.lua
@@ -1,6 +1,5 @@
 local util = require('vim.lsp.util')
 local log = require('vim.lsp.log')
-local ms = require('vim.lsp.protocol').Methods
 local api = vim.api
 local M = {}
 local options = {}
@@ -46,7 +45,6 @@ function M.on_inlayhint(err, result, ctx)
   local bufnr = assert(ctx.bufnr)
   if
     util.buf_versions[bufnr] ~= ctx.version
-    or not result
     or not api.nvim_buf_is_loaded(bufnr)
     or not bufstates[bufnr].enabled
   then
@@ -60,6 +58,9 @@ function M.on_inlayhint(err, result, ctx)
   end
   local client_hints = bufstate.client_hints
   local client = assert(vim.lsp.get_client_by_id(client_id))
+
+  -- If there's no error but the result is nil, clear existing hints.
+  result = result or {}
 
   local new_lnum_hints = vim.defaulttable()
   local num_unprocessed = #result
@@ -85,6 +86,29 @@ function M.on_inlayhint(err, result, ctx)
   api.nvim__redraw({ buf = bufnr, valid = true, flush = false })
 end
 
+--- Refresh inlay hints, only if we have attached clients that support it
+---@param bufnr (integer) Buffer handle, or 0 for current
+---@param client_id? (integer) Client ID, or nil for all
+local function refresh(bufnr, client_id)
+  for _, client in
+    ipairs(vim.lsp.get_clients({
+      bufnr = bufnr,
+      id = client_id,
+      method = 'textDocument/inlayHint',
+    }))
+  do
+    client:request('textDocument/inlayHint', {
+      textDocument = util.make_text_document_params(bufnr),
+      range = util._make_line_range_params(
+        bufnr,
+        0,
+        api.nvim_buf_line_count(bufnr) - 1,
+        client.offset_encoding
+      ),
+    }, nil, bufnr)
+  end
+end
+
 --- |lsp-handler| for the method `workspace/inlayHint/refresh`
 ---@param ctx lsp.HandlerContext
 ---@private
@@ -92,12 +116,12 @@ function M.on_refresh(err, _, ctx)
   if err then
     return vim.NIL
   end
-  for _, bufnr in ipairs(vim.lsp.get_buffers_by_client_id(ctx.client_id)) do
+  for bufnr in pairs(vim.lsp.get_client_by_id(ctx.client_id).attached_buffers or {}) do
     for _, winid in ipairs(api.nvim_list_wins()) do
       if api.nvim_win_get_buf(winid) == bufnr then
         if bufstates[bufnr] and bufstates[bufnr].enabled then
           bufstates[bufnr].applied = {}
-          util._refresh(ms.textDocument_inlayHint, { bufnr = bufnr })
+          refresh(bufnr)
         end
       end
     end
@@ -151,7 +175,7 @@ function M.get(filter)
     --- @param buf integer
     vim.tbl_map(function(buf)
       vim.list_extend(hints, M.get(vim.tbl_extend('keep', { bufnr = buf }, filter)))
-    end, vim.api.nvim_list_bufs())
+    end, api.nvim_list_bufs())
     return hints
   else
     bufnr = vim._resolve_bufnr(bufnr)
@@ -164,7 +188,7 @@ function M.get(filter)
 
   local clients = vim.lsp.get_clients({
     bufnr = bufnr,
-    method = ms.textDocument_inlayHint,
+    method = 'textDocument/inlayHint',
   })
   if #clients == 0 then
     return {}
@@ -229,23 +253,13 @@ local function _disable(bufnr)
   bufstates[bufnr].enabled = false
 end
 
---- Refresh inlay hints, only if we have attached clients that support it
----@param bufnr (integer) Buffer handle, or 0 for current
----@param opts? vim.lsp.util._refresh.Opts Additional options to pass to util._refresh
----@private
-local function _refresh(bufnr, opts)
-  opts = opts or {}
-  opts['bufnr'] = bufnr
-  util._refresh(ms.textDocument_inlayHint, opts)
-end
-
 --- Enable inlay hints for a buffer
 ---@param bufnr (integer) Buffer handle, or 0 for current
 local function _enable(bufnr)
   bufnr = vim._resolve_bufnr(bufnr)
   bufstates[bufnr] = nil
   bufstates[bufnr].enabled = true
-  _refresh(bufnr)
+  refresh(bufnr)
 end
 
 api.nvim_create_autocmd('LspNotify', {
@@ -254,13 +268,13 @@ api.nvim_create_autocmd('LspNotify', {
     local bufnr = args.buf
 
     if
-      args.data.method ~= ms.textDocument_didChange
-      and args.data.method ~= ms.textDocument_didOpen
+      args.data.method ~= 'textDocument/didChange'
+      and args.data.method ~= 'textDocument/didOpen'
     then
       return
     end
     if bufstates[bufnr].enabled then
-      _refresh(bufnr, { client_id = args.data.client_id })
+      refresh(bufnr, args.data.client_id)
     end
   end,
   group = augroup,
@@ -275,7 +289,7 @@ api.nvim_create_autocmd('LspAttach', {
         clear(cb_bufnr)
         if bufstates[cb_bufnr] and bufstates[cb_bufnr].enabled then
           bufstates[cb_bufnr].applied = {}
-          _refresh(cb_bufnr)
+          refresh(cb_bufnr)
         end
       end,
       on_detach = function(_, cb_bufnr)
@@ -290,7 +304,7 @@ api.nvim_create_autocmd('LspDetach', {
   callback = function(args)
     ---@type integer
     local bufnr = args.buf
-    local clients = vim.lsp.get_clients({ bufnr = bufnr, method = ms.textDocument_inlayHint })
+    local clients = vim.lsp.get_clients({ bufnr = bufnr, method = 'textDocument/inlayHint' })
 
     if not vim.iter(clients):any(function(c)
       return c.id ~= args.data.client_id


### PR DESCRIPTION
Current impl is broken on nightly, this PR simply syncs with upstream.

I ported the changes from diff manually. Hope I didn't miss anything.

<details>
<summary>Diff with upstream</summary>

```diff
4a5
> local options = {}
17d17
< 
46d45
< 
319c318
<   on_win = function(_, _, bufnr, topline, botline)
---
>   on_win = function(_, winid, bufnr, topline, botline)
338,339d336
< 
<         local hint_virtual_texts = {} --- @type table<integer, [string, string?][]>
342,354c339,342
<           for _, hint in pairs(hints) do
<             local text = ''
<             local label = hint.label
<             if type(label) == 'string' then
<               text = label
<             else
<               for _, part in ipairs(label) do
<                 text = text .. part.value
<               end
<             end
<             local vt = hint_virtual_texts[hint.position.character] or {}
<             if hint.paddingLeft then
<               vt[#vt + 1] = { ' ' }
---
>           local lhint = options.display_callback(hints, options, bufnr, winid)
>           if lhint then -- skip nil
>             if type(lhint) == 'string' then
>               lhint = { { text = lhint, col = 0 } }
356,358c344,356
<             vt[#vt + 1] = { text, 'LspInlayHint' }
<             if hint.paddingRight then
<               vt[#vt + 1] = { ' ' }
---
>             for _, hint in pairs(lhint) do
>               api.nvim_buf_set_extmark(bufnr, namespace, lnum, hint.col, {
>                 hl_mode = options.hl_mode,
>                 virt_text_pos = options.virt_text_pos,
>                 ephemeral = false,
>                 virt_text = {
>                   {
>                     hint.text,
>                     options.highlight_group,
>                   },
>                 },
>                 priority = options.priority,
>               })
360d357
<             hint_virtual_texts[hint.position.character] = vt
363,371d359
< 
<         for pos, vt in pairs(hint_virtual_texts) do
<           api.nvim_buf_set_extmark(bufnr, namespace, lnum, pos, {
<             virt_text_pos = 'inline',
<             ephemeral = false,
<             virt_text = vt,
<           })
<         end
< 
433a422,533
>     end
>   end
> end
> 
> --- @class InlayHintConfig
> --- @field virt_text_pos 'eol'|'right_align'|'inline'
> --- @field highlight_group string
> --- @field hl_mode 'combine'|'replace'
> --- @field priority number
> --- @field display_callback fun(line_hints: lsp.InlayHint[], options: InlayHintConfig, bufnr: number, winid: number): ({text: string, col: number}[]|string|nil)
> local defaults = {
>   virt_text_pos = 'eol',
>   highlight_group = 'LspInlayHint',
>   hl_mode = 'combine',
>   priority = 1001,
>   display_callback = function(line_hints, options, bufnr, winid)
>     if options.virt_text_pos == 'inline' then
>       local lhint = {}
>       for _, hint in pairs(line_hints) do
>         local text = ''
>         local label = hint.label
>         if type(label) == 'string' then
>           text = label
>         else
>           for _, part in ipairs(label) do
>             text = text .. part.value
>           end
>         end
>         if hint.paddingLeft then
>           text = ' ' .. text
>         end
>         if hint.paddingRight then
>           text = text .. ' '
>         end
>         lhint[#lhint + 1] = { text = text, col = hint.position.character }
>       end
>       return lhint
>     elseif options.virt_text_pos == 'eol' or options.virt_text_pos == 'right_align' then
>       local k1 = {}
>       local k2 = {}
>       table.sort(line_hints, function(a, b)
>         return a.position.character < b.position.character
>       end)
>       for _, hint in pairs(line_hints) do
>         local label = hint.label
>         local kind = hint.kind
>         local text = ''
>         if type(label) == 'string' then
>           text = label
>         else
>           for _, part in ipairs(label) do
>             text = text .. part.value
>           end
>         end
>         if kind == 1 then
>           k1[#k1 + 1] = text:gsub('^:%s*', '')
>         else
>           k2[#k2 + 1] = text:gsub(':$', '')
>         end
>       end
>       local text = ''
>       if #k2 > 0 then
>         text = '<- (' .. table.concat(k2, ',') .. ')'
>       end
>       if #text > 0 then
>         text = text .. ' '
>       end
>       if #k1 > 0 then
>         text = text .. '=> ' .. table.concat(k1, ',')
>       end
> 
>       return text
>     end
>     return nil
>   end,
> }
> 
> --- @class InlayHintPartialConfig
> --- Position of virtual text. Possible values:
> --- 'eol': right after eol character (default).
> --- 'right_align': display right aligned in the window.
> --- 'inline': display at the specified column, and shift the buffer
> --- text to the right as needed.
> --- @field virt_text_pos? 'eol'|'right_align'|'inline'
> --- Can be supplied either as a string or as an integer,
> --- the latter which can be obtained using |nvim_get_hl_id_by_name()|.
> --- @field highlight_group? string
> --- Control how highlights are combined with the
> --- highlights of the text.
> --- 'combine': combine with background text color. (default)
> --- 'replace': only show the virt_text color.
> --- @field hl_mode? 'combine'|'replace'
> --- Set the display priority when multiple extmark are present.
> --- @field priority? number
> --- line_hints: array with all hints present in current line.
> --- options: table with this plugin configuration.
> --- bufnr: buffer id from where the hints come from.
> --- @field display_callback? fun(line_hints: lsp.InlayHint[], options: InlayHintConfig, bufnr: number, winid: number): ({text: string, col: number}[]|string|nil)
> 
> ---Setup/Update inlay-hint.nvim
> ---@param opts InlayHintPartialConfig?
> function M.setup(opts)
>   options = vim.tbl_deep_extend('force', {}, defaults, opts or {})
>   vim.lsp.inlay_hint = M
>   -- NOTE: Redraw inlay_hints, so the user can change the config multiple
>   -- times in the same session
>   for _, client in pairs(vim.lsp.get_clients({ method = 'textDocument/inlayHint' })) do
>     for _, bufnr in ipairs(vim.lsp.get_buffers_by_client_id(client.id)) do
>       if vim.lsp.inlay_hint.is_enabled({ bufnr = bufnr }) then
>         vim.lsp.inlay_hint.enable(false, { bufnr = bufnr })
>         vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })
>       end
```

</details>